### PR TITLE
Add optional compile-time check for number of strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,5 +4,11 @@ project(EnumStrings LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 enable_testing()
 
+if (MSVC)
+  add_compile_options(/W4 /WX)
+else()
+  add_compile_options(-Wall -Wextra -pedantic -Werror)
+endif()
+
 add_executable(testEnumStrings test.cpp)
 add_test(NAME testEnumStrings COMMAND testEnumStrings)

--- a/test.cpp
+++ b/test.cpp
@@ -47,7 +47,7 @@ namespace N3
   {
     enum class NestedEnum { A, B, END };
   };
-  ENUM_STRINGS(Foo::NestedEnum, "fa", "fb",);
+  ENUM_STRINGS(Foo::NestedEnum, "fa", "fb");
 }
 
 ///////////////////////////////

--- a/test.cpp
+++ b/test.cpp
@@ -31,7 +31,7 @@ void test_get_strings(ARGS && ... args)
 
 namespace N1
 {
-  enum WeakEnum { A, B };
+  enum WeakEnum { A, B, END };
   ENUM_STRINGS(WeakEnum, "wa", "wb");
 }
 
@@ -45,9 +45,9 @@ namespace N3
 {
   struct Foo
   {
-    enum class NestedEnum { A, B };
+    enum class NestedEnum { A, B, END };
   };
-  ENUM_STRINGS(Foo::NestedEnum, "fa", "fb");
+  ENUM_STRINGS(Foo::NestedEnum, "fa", "fb",);
 }
 
 ///////////////////////////////


### PR DESCRIPTION
- Add compile-time check for number of strings against E::END, when present.
- Add strict compiler flags.